### PR TITLE
ci: Add GitHub Packages publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,6 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
       packages: write
     steps:
       - uses: actions/checkout@v4
@@ -73,6 +74,6 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
 
       - name: Publish to GitHub Packages
-        run: npm publish --access public
+        run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Enable publishing to GitHub Packages in addition to npmjs.org, so the package appears at https://github.com/bayinformatics/croppie/packages.

## Changes

- Split the publish workflow into 3 jobs:
  - `build`: Builds the package and uploads artifacts
  - `publish-npm`: Publishes to npmjs.org (existing behavior)
  - `publish-github`: Publishes to GitHub Packages npm registry

- The npm and GitHub publish jobs run in parallel after the build completes
- Uses `GITHUB_TOKEN` for GitHub Packages auth (no additional secrets needed)
- Shared build artifacts ensure both registries get identical builds

## To Publish

After merging, you can either:
1. **Create a new release** (v3.0.1) - triggers both publishes
2. **Manually run the workflow** - but note that v3.0.0 is already on npm, so only GitHub Packages would succeed

For GitHub Packages to show v3.0.0, we'd need to run the GitHub Packages publish manually or bump version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Restructured CI workflow to separate build and publish stages for clearer build artifact handling.
  * Build now uploads distribution artifacts after compilation for downstream publishing.
  * Publishing paths expanded: package is published to both npm and GitHub Packages registries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->